### PR TITLE
bump csnappy code

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 Revision history for Compress-Snappy
 
+0.25 Wed May 15 11:50:00 UTC 2024
+    - Synchronized csnappy with upstream
+
 0.24  Tue May 12 19:16:28 UTC 2015
     - Allowed 'magical' input.
     - Integrated latest csnappy source.

--- a/lib/Compress/Snappy.pm
+++ b/lib/Compress/Snappy.pm
@@ -6,7 +6,7 @@ use warnings;
 use Exporter qw(import);
 use XSLoader;
 
-our $VERSION    = '0.24';
+our $VERSION    = '0.25';
 our $XS_VERSION = $VERSION;
 $VERSION = eval $VERSION;
 

--- a/src/csnappy.h
+++ b/src/csnappy.h
@@ -16,7 +16,12 @@ extern "C" {
 #ifndef __GNUC__
 #define __attribute__(x) /*NOTHING*/
 #endif
-#include <stdint.h>
+
+#if defined(__SUNPRO_C) || defined(_AIX)
+# include <inttypes.h>
+#else
+# include <stdint.h>
+#endif
 
 /*
  * Returns the maximal size of the compressed representation of

--- a/src/csnappy_compress.c
+++ b/src/csnappy_compress.c
@@ -86,7 +86,7 @@ encode_varint32(char *sptr, uint32_t v)
 #define kBlockSize (1 << kBlockLog)
 
 
-#if defined(__arm__) && !(ARCH_ARM_HAVE_UNALIGNED)
+#if defined(__arm__) && !defined(ARCH_ARM_HAVE_UNALIGNED)
 
 static uint8_t* emit_literal(
 	uint8_t *op,
@@ -249,7 +249,7 @@ static INLINE uint32_t Hash(const char *p, int shift)
  * Separate implementation for x86_64, for speed.  Uses the fact that
  * x86_64 is little endian.
  */
-#if defined(__x86_64__)
+#if defined(__x86_64__) || defined(__aarch64__)
 static INLINE int
 FindMatchLength(const char *s1, const char *s2, const char *s2_limit)
 {
@@ -293,7 +293,7 @@ FindMatchLength(const char *s1, const char *s2, const char *s2_limit)
 	}
 	return matched;
 }
-#else /* !defined(__x86_64__) */
+#else /* !defined(__x86_64__) && !defined(__aarch64__) */
 static INLINE int
 FindMatchLength(const char *s1, const char *s2, const char *s2_limit)
 {
@@ -326,7 +326,7 @@ FindMatchLength(const char *s1, const char *s2, const char *s2_limit)
 #endif
 	return matched;
 }
-#endif /* !defined(__x86_64__) */
+#endif /* !defined(__x86_64__) && !defined(__aarch64__) */
 
 
 static INLINE char*

--- a/src/csnappy_decompress.c
+++ b/src/csnappy_decompress.c
@@ -73,7 +73,7 @@ err_out:
 EXPORT_SYMBOL(csnappy_get_uncompressed_length);
 #endif
 
-#if defined(__arm__) && !(ARCH_ARM_HAVE_UNALIGNED)
+#if defined(__arm__) && !defined(ARCH_ARM_HAVE_UNALIGNED)
 int csnappy_decompress_noheader(
 	const char	*src_,
 	uint32_t	src_remaining,
@@ -271,7 +271,7 @@ SAW__AppendFastPath(struct SnappyArrayWriter *this,
 		UnalignedCopy64(ip, op);
 		UnalignedCopy64(ip + 8, op + 8);
 	} else {
-                if (unlikely(space_left < (int32_t)len))
+                if (unlikely(space_left < len))
 			return CSNAPPY_E_OUTPUT_OVERRUN;
 		memcpy(op, ip, len);
 	}
@@ -285,7 +285,7 @@ SAW__Append(struct SnappyArrayWriter *this,
 {
 	char *op = this->op;
 	const uint32_t space_left = this->op_limit - op;
-        if (unlikely(space_left < (int32_t)len))
+        if (unlikely(space_left < len))
 		return CSNAPPY_E_OUTPUT_OVERRUN;
 	memcpy(op, ip, len);
 	this->op = op + len;
@@ -305,10 +305,10 @@ SAW__AppendFromSelf(struct SnappyArrayWriter *this,
 	if (len <= 16 && offset >= 8 && space_left >= 16) {
 		UnalignedCopy64(op - offset, op);
 		UnalignedCopy64(op - offset + 8, op + 8);
-        } else if (space_left >= (int32_t)(len + kMaxIncrementCopyOverflow)) {
+        } else if (space_left >= (len + kMaxIncrementCopyOverflow)) {
 		IncrementalCopyFastPath(op - offset, op, len);
 	} else {
-                if (space_left < (int32_t)len)
+                if (space_left < len)
 			return CSNAPPY_E_OUTPUT_OVERRUN;
 		IncrementalCopy(op - offset, op, len);
 	}

--- a/src/csnappy_internal.h
+++ b/src/csnappy_internal.h
@@ -86,12 +86,14 @@ Steffen Mueller <smueller@cpan.org>
 #  error either __LITTLE_ENDIAN or __BIG_ENDIAN, plus __BYTE_ORDER must be defined
 #endif
 
-#define ARCH_ARM_HAVE_UNALIGNED \
-    defined(__ARM_ARCH_6__) || defined(__ARM_ARCH_6J__) || defined(__ARM_ARCH_6K__) || defined(__ARM_ARCH_6Z__) || defined(__ARM_ARCH_6ZK__) || defined(__ARM_ARCH_6T2__) || defined(__ARMV6__) || \
+#if defined(__ARM_ARCH_6__) || defined(__ARM_ARCH_6J__) || defined(__ARM_ARCH_6K__) || defined(__ARM_ARCH_6Z__) || defined(__ARM_ARCH_6ZK__) || defined(__ARM_ARCH_6T2__) || defined(__ARMV6__) || \
     defined(__ARM_ARCH_7__) || defined(__ARM_ARCH_7A__) || defined(__ARM_ARCH_7R__) || defined(__ARM_ARCH_7M__)
+#  define ARCH_ARM_HAVE_UNALIGNED
+#endif
+
 
 static INLINE void UnalignedCopy64(const void *src, void *dst) {
-#if defined(__i386__) || defined(__x86_64__) || defined(__powerpc__) || ARCH_ARM_HAVE_UNALIGNED
+#if defined(__i386__) || defined(__x86_64__) || defined(__powerpc__) || defined(ARCH_ARM_HAVE_UNALIGNED) || defined(__aarch64__)
   if ((sizeof(void *) == 8) || (sizeof(long) == 8)) {
     UNALIGNED_STORE64(dst, UNALIGNED_LOAD64(src));
   } else {
@@ -118,7 +120,7 @@ static INLINE void UnalignedCopy64(const void *src, void *dst) {
 }
 
 #if defined(__arm__)
-  #if ARCH_ARM_HAVE_UNALIGNED
+  #if defined(ARCH_ARM_HAVE_UNALIGNED)
      static INLINE uint32_t get_unaligned_le(const void *p, uint32_t n)
      {
        uint32_t wordmask = (1U << (8 * n)) - 1;


### PR DESCRIPTION
Bumping csnappy to 6c10c305e8dde193546e6b33cf8a785d5dc123e2 from https://github.com/zeevt/csnappy before this we were getting bad decompression results on CentOS9

This PR should be enough to release a new cpan package